### PR TITLE
fix!: community models should not inherit from `Statement` / `EvidenceLine`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "ga4gh.vrs==2.*",
-    "ga4gh.cat_vrs~-0.5.0",
+    "ga4gh.cat_vrs~=0.5.0",
     "pydantic==2.*"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "ga4gh.vrs==2.*",
-    "ga4gh.cat_vrs~=0.4.0",
+    "ga4gh.cat_vrs~-0.5.0",
     "pydantic==2.*"
 ]
 

--- a/src/ga4gh/va_spec/aac_2017/models.py
+++ b/src/ga4gh/va_spec/aac_2017/models.py
@@ -9,7 +9,7 @@ from enum import Enum
 from ga4gh.core.models import MappableConcept, iriReference
 from ga4gh.va_spec.base.core import (
     Method,
-    Statement,
+    StatementValidatorMixin,
     VariantDiagnosticProposition,
     VariantPrognosticProposition,
     VariantTherapeuticResponseProposition,
@@ -17,6 +17,7 @@ from ga4gh.va_spec.base.core import (
 from ga4gh.va_spec.base.enums import System
 from ga4gh.va_spec.base.validators import validate_mappable_concept
 from pydantic import (
+    BaseModel,
     Field,
     field_validator,
 )
@@ -46,8 +47,11 @@ class Classification(str, Enum):
 AMP_ASCO_CAP_TIERS = [v.value for v in Classification.__members__.values()]
 
 
-class _ValidatorMixin:
-    """Mixin class for reusable AMP/ASCO/CAP field validators"""
+class AmpAscoCapValidatorMixin(StatementValidatorMixin):
+    """Mixin class for reusable AMP/ASCO/CAP field validators
+
+    Should be used with classes that inherit from Pydantic BaseModel
+    """
 
     @field_validator("strength")
     @classmethod
@@ -74,7 +78,7 @@ class _ValidatorMixin:
         return validate_mappable_concept(v, System.AMP_ASCO_CAP, AMP_ASCO_CAP_TIERS)
 
 
-class VariantDiagnosticStudyStatement(Statement, _ValidatorMixin):
+class VariantDiagnosticStudyStatement(BaseModel, AmpAscoCapValidatorMixin):
     """A statement reporting a conclusion from a single study about whether a variant is
     associated with a disease (a diagnostic inclusion criterion), or absence of a
     disease (diagnostic exclusion criterion) - based on interpretation of the study's
@@ -99,7 +103,7 @@ class VariantDiagnosticStudyStatement(Statement, _ValidatorMixin):
     )
 
 
-class VariantPrognosticStudyStatement(Statement, _ValidatorMixin):
+class VariantPrognosticStudyStatement(BaseModel, AmpAscoCapValidatorMixin):
     """A statement reporting a conclusion from a single study about whether a variant is
     associated with a disease prognosis - based on interpretation of the study's
     results.
@@ -123,7 +127,7 @@ class VariantPrognosticStudyStatement(Statement, _ValidatorMixin):
     )
 
 
-class VariantTherapeuticResponseStudyStatement(Statement, _ValidatorMixin):
+class VariantTherapeuticResponseStudyStatement(BaseModel, AmpAscoCapValidatorMixin):
     """A statement reporting a conclusion from a single study about whether a variant is
     associated with a therapeutic response (positive or negative) - based on
     interpretation of the study's results.

--- a/src/ga4gh/va_spec/acmg_2015/models.py
+++ b/src/ga4gh/va_spec/acmg_2015/models.py
@@ -164,9 +164,10 @@ class VariantPathogenicityStatement(BaseModel, StatementValidatorMixin):
             err_msg = "`primaryCoding` is required."
             raise ValueError(err_msg)
 
-        supported_systems = [System.ACMG.value, System.ACMG.value]
+        supported_systems = [System.ACMG.value, System.CLIN_GEN.value]
         if v.primaryCoding.system not in supported_systems:
             err_msg = f"`primaryCoding.system` must be one of: {supported_systems}."
+            raise ValueError(err_msg)
 
         if v.primaryCoding.system == System.ACMG:
             if v.primaryCoding.code.root not in ACMG_CLASSIFICATIONS:

--- a/src/ga4gh/va_spec/base/__init__.py
+++ b/src/ga4gh/va_spec/base/__init__.py
@@ -27,9 +27,11 @@ from .core import (
 )
 from .domain_entities import Condition, ConditionSet, Therapeutic, TherapyGroup
 from .enums import (
+    CCV_CLASSIFICATIONS,
     CLIN_GEN_CLASSIFICATIONS,
     STRENGTH_OF_EVIDENCE_PROVIDED_VALUES,
     STRENGTHS,
+    CcvClassification,
     ClinGenClassification,
     DiagnosticPredicate,
     MembershipOperator,
@@ -42,7 +44,9 @@ from .enums import (
 
 __all__ = [
     "Agent",
+    "CCV_CLASSIFICATIONS",
     "CLIN_GEN_CLASSIFICATIONS",
+    "CcvClassification",
     "ClinGenClassification",
     "ClinGenClassification",
     "ClinicalVariantProposition",

--- a/src/ga4gh/va_spec/base/core.py
+++ b/src/ga4gh/va_spec/base/core.py
@@ -563,12 +563,13 @@ class EvidenceLine(InformationEntity, BaseModelForbidExtra):
                         found_model = True
                         break
                 if not found_model:
-                    err_msg = "Unable to find valid model"
+                    err_msg = "Unable to find valid model for `hasEvidenceItems`"
                     raise ValueError(err_msg)
             elif isinstance(evidence_item, str):
                 evidence_items.append(iriReference(root=evidence_item))
             else:
-                evidence_items.append(evidence_item)
+                err_msg = "Unable to find valid model for `hasEvidenceItems`"
+                raise ValueError(err_msg)
         return evidence_items
 
 

--- a/src/ga4gh/va_spec/base/core.py
+++ b/src/ga4gh/va_spec/base/core.py
@@ -700,6 +700,6 @@ class EvidenceLineValidatorMixin:
         try:
             EvidenceLine(**model.model_dump())
         except ValidationError as e:
-            err_msg = f"Must be a `EvidenceLine`: {e}"
+            err_msg = f"Must be an `EvidenceLine`: {e}"
             raise ValueError(err_msg) from e
         return model

--- a/src/ga4gh/va_spec/base/enums.py
+++ b/src/ga4gh/va_spec/base/enums.py
@@ -75,6 +75,19 @@ class ClinGenClassification(str, Enum):
 CLIN_GEN_CLASSIFICATIONS = [v.value for v in ClinGenClassification.__members__.values()]
 
 
+class CcvClassification(str, Enum):
+    """Define constraints for CCV classifications"""
+
+    ONCOGENIC = "oncogenic"
+    LIKELY_ONCOGENIC = "likely oncogenic"
+    UNCERTAIN_SIGNIFICANCE = "uncertain significance"
+    LIKELY_BENIGN = "likely benign"
+    BENIGN = "benign"
+
+
+CCV_CLASSIFICATIONS = [v.value for v in CcvClassification.__members__.values()]
+
+
 class System(str, Enum):
     """Define constraints for systems"""
 

--- a/src/ga4gh/va_spec/ccv_2022/models.py
+++ b/src/ga4gh/va_spec/ccv_2022/models.py
@@ -13,7 +13,7 @@ from ga4gh.va_spec.base.core import (
     VariantOncogenicityProposition,
 )
 from ga4gh.va_spec.base.enums import (
-    CLIN_GEN_CLASSIFICATIONS,
+    CCV_CLASSIFICATIONS,
     STRENGTH_OF_EVIDENCE_PROVIDED_VALUES,
     STRENGTHS,
     System,
@@ -133,5 +133,5 @@ class VariantOncogenicityStudyStatement(BaseModel, StatementValidatorMixin):
         :return: Validated classification value
         """
         return validate_mappable_concept(
-            v, System.CLIN_GEN, CLIN_GEN_CLASSIFICATIONS, mc_is_required=True
+            v, System.CLIN_GEN, CCV_CLASSIFICATIONS, mc_is_required=True
         )

--- a/src/ga4gh/va_spec/ccv_2022/models.py
+++ b/src/ga4gh/va_spec/ccv_2022/models.py
@@ -119,9 +119,7 @@ class VariantOncogenicityStudyStatement(BaseModel, StatementValidatorMixin):
         :raises ValueError: If invalid strength values are provided
         :return: Validated strength value
         """
-        return validate_mappable_concept(
-            v, System.CLIN_GEN, STRENGTHS, mc_is_required=False
-        )
+        return validate_mappable_concept(v, System.CCV, STRENGTHS, mc_is_required=False)
 
     @field_validator("classification")
     @classmethod
@@ -133,5 +131,5 @@ class VariantOncogenicityStudyStatement(BaseModel, StatementValidatorMixin):
         :return: Validated classification value
         """
         return validate_mappable_concept(
-            v, System.CLIN_GEN, CCV_CLASSIFICATIONS, mc_is_required=True
+            v, System.CCV, CCV_CLASSIFICATIONS, mc_is_required=True
         )

--- a/src/ga4gh/va_spec/ccv_2022/models.py
+++ b/src/ga4gh/va_spec/ccv_2022/models.py
@@ -7,9 +7,9 @@ from enum import Enum
 
 from ga4gh.core.models import MappableConcept, iriReference
 from ga4gh.va_spec.base.core import (
-    EvidenceLine,
+    EvidenceLineValidatorMixin,
     Method,
-    Statement,
+    StatementValidatorMixin,
     VariantOncogenicityProposition,
 )
 from ga4gh.va_spec.base.enums import (
@@ -19,7 +19,7 @@ from ga4gh.va_spec.base.enums import (
     System,
 )
 from ga4gh.va_spec.base.validators import validate_mappable_concept
-from pydantic import Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class EvidenceOutcome(str, Enum):
@@ -38,7 +38,9 @@ class EvidenceOutcome(str, Enum):
 EVIDENCE_OUTCOME_VALUES = [v.value for v in EvidenceOutcome.__members__.values()]
 
 
-class VariantOncogenicityFunctionalImpactEvidenceLine(EvidenceLine):
+class VariantOncogenicityFunctionalImpactEvidenceLine(
+    BaseModel, EvidenceLineValidatorMixin
+):
     """An Evidence Line that describes how information about the functional impact of a
     variant on a gene or gene product was interpreted as evidence for or against the
     variant's oncogenicity.
@@ -72,23 +74,21 @@ class VariantOncogenicityFunctionalImpactEvidenceLine(EvidenceLine):
             v, System.CCV, STRENGTH_OF_EVIDENCE_PROVIDED_VALUES, mc_is_required=False
         )
 
-    @field_validator("evidenceOutcome")
-    @classmethod
-    def validate_evidence_outcome(
-        cls, v: MappableConcept | None
-    ) -> MappableConcept | None:
-        """Validate evidenceOutcome
+    @model_validator(mode="before")
+    def validate_evidence_outcome(cls, values: dict) -> dict:  # noqa: N805
+        """Validate ``evidenceOutcome`` property if it exists
 
-        :param v: evidenceOutcome
-        :raises ValueError: If invalid evidenceOutcome values are provided
-        :return: Validated evidenceOutcome value
+        :param values: Input values
+        :raises ValueError: If ``evidenceOutcome`` exists and is invalid
+        :return: Validated input values. If ``evidenceOutcome`` exists, then it will be
+            validated and converted to a ``MappableConcept``
         """
-        return validate_mappable_concept(
-            v, System.CCV, EVIDENCE_OUTCOME_VALUES, mc_is_required=False
+        return cls._validate_evidence_outcome(
+            values, System.CCV, EVIDENCE_OUTCOME_VALUES
         )
 
 
-class VariantOncogenicityStudyStatement(Statement):
+class VariantOncogenicityStudyStatement(BaseModel, StatementValidatorMixin):
     """A statement reporting a conclusion from a single study about whether a
     variant is associated with oncogenicity (positive or negative) - based on
     interpretation of the study's results.

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -4,15 +4,21 @@ import json
 
 import pytest
 import yaml
-from ga4gh.core.models import iriReference
+from ga4gh.core.models import Coding, MappableConcept, code, iriReference
 from ga4gh.va_spec import acmg_2015, base, ccv_2022
 from ga4gh.va_spec.aac_2017.models import VariantTherapeuticResponseStudyStatement
+from ga4gh.va_spec.acmg_2015.models import (
+    VariantPathogenicityFunctionalImpactEvidenceLine,
+)
 from ga4gh.va_spec.base import (
     Agent,
     CohortAlleleFrequencyStudyResult,
     ExperimentalVariantFunctionalImpactStudyResult,
 )
 from ga4gh.va_spec.base.core import EvidenceLine, StudyGroup, StudyResult
+from ga4gh.va_spec.ccv_2022.models import (
+    VariantOncogenicityFunctionalImpactEvidenceLine,
+)
 from pydantic import ValidationError
 
 from tests.conftest import SUBMODULES_DIR
@@ -198,6 +204,66 @@ def test_evidence_line(caf):
     }
     el = EvidenceLine(**el_dict)
     assert isinstance(el.hasEvidenceItems[0], iriReference)
+
+
+def test_variant_pathogenicity_el():
+    """Ensure VariantPathogenicityFunctionalImpactEvidenceLine model works as expected"""
+    vp = VariantPathogenicityFunctionalImpactEvidenceLine(
+        type="EvidenceLine",
+        specifiedBy={
+            "type": "Method",
+            "id": "PS3",
+            "name": "ACMG 2015 PS3 Criterion",
+            "reportedIn": {
+                "type": "Document",
+                "pmid": 25741868,
+                "name": "ACMG Guidelines, 2015",
+            },
+        },
+        directionOfEvidenceProvided="supports",
+        evidenceOutcome={
+            "primaryCoding": {
+                "code": "PS3_supporting",
+                "system": "ACMG Guidelines, 2015",
+            },
+            "name": "ACMG 2015 PS3 Supporting Criterion Met",
+        },
+    )
+    assert vp.evidenceOutcome == MappableConcept(
+        primaryCoding=Coding(
+            code=code(root="PS3_supporting"), system="ACMG Guidelines, 2015"
+        ),
+        name="ACMG 2015 PS3 Supporting Criterion Met",
+    )
+
+
+def test_variant_onco_el():
+    """Ensure VariantOncogenicityFunctionalImpactEvidenceLine model works as expected"""
+    vp = VariantOncogenicityFunctionalImpactEvidenceLine(
+        type="EvidenceLine",
+        specifiedBy={
+            "type": "Method",
+            "reportedIn": {
+                "type": "Document",
+                "pmid": 35101336,
+                "name": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
+            },
+        },
+        directionOfEvidenceProvided="supports",
+        scoreOfEvidenceProvided=1,
+        evidenceOutcome={
+            "primaryCoding": {
+                "code": "OS2_supporting",
+                "system": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
+            },
+        },
+    )
+    assert vp.evidenceOutcome == MappableConcept(
+        primaryCoding=Coding(
+            code=code(root="OS2_supporting"),
+            system="ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
+        ),
+    )
 
 
 def test_examples(test_definitions):

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -20,6 +20,7 @@ from ga4gh.va_spec.base import (
 from ga4gh.va_spec.base.core import EvidenceLine, Method, StudyGroup, StudyResult
 from ga4gh.va_spec.ccv_2022.models import (
     VariantOncogenicityFunctionalImpactEvidenceLine,
+    VariantOncogenicityStudyStatement,
 )
 from pydantic import ValidationError
 
@@ -297,6 +298,55 @@ def test_variant_pathogenicity_el():
     del invalid_params["specifiedBy"]["reportedIn"]
     with pytest.raises(ValueError, match="`reportedIn` is required"):
         VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
+
+
+def test_variant_onco_stmt():
+    """Ensure VariantOncogenicityStudyStatement model works as expected"""
+    params = {
+        "direction": "neutral",
+        "proposition": {
+            "type": "VariantOncogenicityProposition",
+            "predicate": "isCausalFor",
+            "objectTumorType": "conditions.json#/1",
+            "subjectVariant": "alleles.json#/1",
+        },
+        "classification": {
+            "primaryCoding": {
+                "code": "oncogenic",
+                "system": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024",
+            }
+        },
+        "specifiedBy": "documents.json#/1",
+        "strength": {
+            "primaryCoding": {
+                "code": "definitive",
+                "system": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024",
+            }
+        },
+    }
+    assert VariantOncogenicityStudyStatement(**params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["strength"]["primaryCoding"]["code"] = "oncogenic"
+    with pytest.raises(ValueError, match="`primaryCoding.code` must be one of"):
+        VariantOncogenicityStudyStatement(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["strength"]["primaryCoding"]["system"] = "ACMG Guidelines, 2015"
+    with pytest.raises(ValueError, match="`primaryCoding.system` must be"):
+        VariantOncogenicityStudyStatement(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["classification"]["primaryCoding"]["code"] = "pathogenic"
+    with pytest.raises(ValueError, match="`primaryCoding.code` must be one of"):
+        VariantOncogenicityStudyStatement(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["classification"]["primaryCoding"]["system"] = (
+        "ACMG Guidelines, 2015"
+    )
+    with pytest.raises(ValueError, match="`primaryCoding.system` must be"):
+        VariantOncogenicityStudyStatement(**invalid_params)
 
 
 def test_variant_onco_el():

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -15,7 +15,7 @@ from ga4gh.va_spec.base import (
     CohortAlleleFrequencyStudyResult,
     ExperimentalVariantFunctionalImpactStudyResult,
 )
-from ga4gh.va_spec.base.core import EvidenceLine, StudyGroup, StudyResult
+from ga4gh.va_spec.base.core import EvidenceLine, Method, StudyGroup, StudyResult
 from ga4gh.va_spec.ccv_2022.models import (
     VariantOncogenicityFunctionalImpactEvidenceLine,
 )
@@ -229,6 +229,8 @@ def test_variant_pathogenicity_el():
             "name": "ACMG 2015 PS3 Supporting Criterion Met",
         },
     )
+
+    assert isinstance(vp.specifiedBy, Method)
     assert vp.evidenceOutcome == MappableConcept(
         primaryCoding=Coding(
             code=code(root="PS3_supporting"), system="ACMG Guidelines, 2015"
@@ -258,6 +260,7 @@ def test_variant_onco_el():
             },
         },
     )
+    assert isinstance(vo.specifiedBy, Method)
     assert vo.evidenceOutcome == MappableConcept(
         primaryCoding=Coding(
             code=code(root="OS2_supporting"),

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -378,14 +378,14 @@ def test_variant_onco_stmt():
         "classification": {
             "primaryCoding": {
                 "code": "oncogenic",
-                "system": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024",
+                "system": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
             }
         },
         "specifiedBy": "documents.json#/1",
         "strength": {
             "primaryCoding": {
                 "code": "definitive",
-                "system": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024",
+                "system": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
             }
         },
     }

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -208,6 +208,33 @@ def test_evidence_line(caf):
     el = EvidenceLine(**el_dict)
     assert isinstance(el.hasEvidenceItems[0], iriReference)
 
+    el_dict = {
+        "type": "EvidenceLine",
+        "hasEvidenceItems": None,
+        "directionOfEvidenceProvided": "supports",
+    }
+    assert EvidenceLine(**el_dict)
+
+    invalid_params = {
+        "type": "EvidenceLine",
+        "hasEvidenceItems": [Agent(name="Joe")],
+        "directionOfEvidenceProvided": "supports",
+    }
+    with pytest.raises(
+        ValueError, match="Unable to find valid model for `hasEvidenceItems`"
+    ):
+        EvidenceLine(**invalid_params)
+
+    invalid_params = {
+        "type": "EvidenceLine",
+        "hasEvidenceItems": [{"type": "Statement"}],
+        "directionOfEvidenceProvided": "supports",
+    }
+    with pytest.raises(
+        ValueError, match="Unable to find valid model for `hasEvidenceItems`"
+    ):
+        EvidenceLine(**invalid_params)
+
 
 def test_variant_pathogenicity_stmt():
     """Ensure VariantPathogenicityStatement model works as expected"""
@@ -260,6 +287,11 @@ def test_variant_pathogenicity_stmt():
     with pytest.raises(ValueError, match="`primaryCoding.code` must be one of"):
         VariantPathogenicityStatement(**invalid_params)
 
+    invalid_params = deepcopy(params)
+    del invalid_params["proposition"]  # proposition is required for statement
+    with pytest.raises(ValueError, match="Must be a `Statement`"):
+        VariantPathogenicityStatement(**invalid_params)
+
 
 def test_variant_pathogenicity_el():
     """Ensure VariantPathogenicityFunctionalImpactEvidenceLine model works as expected"""
@@ -294,9 +326,42 @@ def test_variant_pathogenicity_el():
         name="ACMG 2015 PS3 Supporting Criterion Met",
     )
 
+    valid_params = deepcopy(params)
+    valid_params["strengthOfEvidenceProvided"] = None
+    assert VariantPathogenicityFunctionalImpactEvidenceLine(**valid_params)
+
     invalid_params = deepcopy(params)
     del invalid_params["specifiedBy"]["reportedIn"]
     with pytest.raises(ValueError, match="`reportedIn` is required"):
+        VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    del invalid_params[
+        "directionOfEvidenceProvided"
+    ]  # directionOfEvidenceProvided is required for statement
+    with pytest.raises(ValueError, match="Must be an `EvidenceLine`"):
+        VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["strengthOfEvidenceProvided"] = {"name": "test"}
+    with pytest.raises(ValueError, match="`primaryCoding` is required."):
+        VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["strengthOfEvidenceProvided"] = {
+        "primaryCoding": {
+            "system": "AMP/ASCO/CAP (AAC) Guidelines, 2017",
+            "code": "strong",
+        }
+    }
+    with pytest.raises(ValueError, match="`primaryCoding.system` must be"):
+        VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
+
+    invalid_params = deepcopy(params)
+    invalid_params["strengthOfEvidenceProvided"] = {
+        "primaryCoding": {"system": "ACMG Guidelines, 2015", "code": "PS3"}
+    }
+    with pytest.raises(ValueError, match="`primaryCoding.code` must be"):
         VariantPathogenicityFunctionalImpactEvidenceLine(**invalid_params)
 
 

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -239,7 +239,7 @@ def test_variant_pathogenicity_el():
 
 def test_variant_onco_el():
     """Ensure VariantOncogenicityFunctionalImpactEvidenceLine model works as expected"""
-    vp = VariantOncogenicityFunctionalImpactEvidenceLine(
+    vo = VariantOncogenicityFunctionalImpactEvidenceLine(
         type="EvidenceLine",
         specifiedBy={
             "type": "Method",
@@ -258,7 +258,7 @@ def test_variant_onco_el():
             },
         },
     )
-    assert vp.evidenceOutcome == MappableConcept(
+    assert vo.evidenceOutcome == MappableConcept(
         primaryCoding=Coding(
             code=code(root="OS2_supporting"),
             system="ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",


### PR DESCRIPTION
close #21

* Use model validator instead of inheriting from `Statement` or `EvidenceLine`
  * `VariantOncogenicityFunctionalImpactEvidenceLine` and `VariantPathogenicityFunctionalImpactEvidenceLine` should NOT inherit from `EvidenceLine`
  * `VariantOncogenicityStudyStatement`, `VariantPathogenicityStatement`, `VariantDiagnosticStudyStatement`, `VariantPrognosticStudyStatement`, and `VariantTherapeuticResponseStudyStatement` should NOT inherit from `Statement`