### PR TITLE
fix: fix pytest-cov settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,6 @@ where = ["src"]
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]
-addopts = "--cov-report=term-missing --cov=ga4gh"
-testpaths = ["tests", "src"]
+addopts = "--cov-report=term-missing --cov=ga4gh.va_spec"
+testpaths = ["tests"]
 doctest_optionflags = "ALLOW_UNICODE ALLOW_BYTES ELLIPSIS IGNORE_EXCEPTION_DETAIL NORMALIZE_WHITESPACE"


### PR DESCRIPTION
@jsstevenson pointed this out in cat-vrs-python (https://github.com/ga4gh/cat-vrs-python/pull/34)