### PR TITLE
ci: remove `get_branch` job in pypi release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,25 +4,9 @@ on:
     tags:
       - "*.*.**"
 jobs:
-  get_branch:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_name: ${{ steps.get_branch_name.outputs.name }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Get branch name
-        id: get_branch_name
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=$(echo "$raw" | grep "origin/main" | grep -v "HEAD" | sed "s|origin/||" | xargs)
-          echo "name=$branch" >> "$GITHUB_OUTPUT"
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-    needs: get_branch
-    if: needs.get_branch.outputs.branch_name == 'main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Had to do similar PRs in both VRS-Python and Cat-VRS Python (https://github.com/ga4gh/cat-vrs-python/pull/39)