### PR TITLE
fix: oncogenicity evidence lines should accept null evidence outcomes

### DIFF
--- a/src/ga4gh/va_spec/base/validators.py
+++ b/src/ga4gh/va_spec/base/validators.py
@@ -121,7 +121,7 @@ class MethodTypeCriterionValidationMixin(Generic[MethodTypeT, CriterionT]):
         :param method_type: Method type value from ``specifiedBy.methodType``.
         :param evidence_outcome_code: Evidence outcome to validate.
         :raises ValueError: If the evidence outcome criterion is invalid or is
-            not valid for the specified method type.
+            not valid for the specified method type, or if method type is invalid
         """
         parsed_method_type = cls.MethodType(method_type)
         allowed_criteria = cls.ALLOWED_CRITERIA_BY_METHOD_TYPE[parsed_method_type]

--- a/src/ga4gh/va_spec/base/validators.py
+++ b/src/ga4gh/va_spec/base/validators.py
@@ -114,7 +114,7 @@ class MethodTypeCriterionValidationMixin(Generic[MethodTypeT, CriterionT]):
     def _validate_method_type_evidence_outcome(
         cls,
         method_type: str,
-        evidence_outcome_code: str,
+        evidence_outcome_code: str | None,
     ) -> None:
         """Validate that ``evidenceOutcome`` is compatible with a method type.
 
@@ -122,10 +122,12 @@ class MethodTypeCriterionValidationMixin(Generic[MethodTypeT, CriterionT]):
         :param evidence_outcome_code: Evidence outcome to validate.
         :raises ValueError: If the evidence outcome criterion is invalid or is
             not valid for the specified method type.
-        :return: None.
         """
         parsed_method_type = cls.MethodType(method_type)
         allowed_criteria = cls.ALLOWED_CRITERIA_BY_METHOD_TYPE[parsed_method_type]
+
+        if not evidence_outcome_code:
+            return
 
         criterion = cls._get_base_criterion_from_code(evidence_outcome_code)
 

--- a/src/ga4gh/va_spec/ccv_2022/models.py
+++ b/src/ga4gh/va_spec/ccv_2022/models.py
@@ -234,11 +234,14 @@ class VariantOncogenicityEvidenceLine(EvidenceLine, MethodTypeCriterionValidatio
             ``directionOfEvidenceProvided`` is neutral
         """
         self._validate_direction_of_evidence_provided()
-        self._validate_evidence_outcome(SYSTEM, CCV_CODE_PATTERN, is_required=True)
+        self._validate_evidence_outcome(SYSTEM, CCV_CODE_PATTERN, is_required=False)
         self._validate_criterion_specified_by()
-        self._validate_method_type_evidence_outcome(
-            self.specifiedBy.methodType, self.evidenceOutcome.primaryCoding.code.root
-        )
+
+        if self.evidenceOutcome:
+            self._validate_method_type_evidence_outcome(
+                self.specifiedBy.methodType,
+                self.evidenceOutcome.primaryCoding.code.root,
+            )
         return self
 
 

--- a/src/ga4gh/va_spec/ccv_2022/models.py
+++ b/src/ga4gh/va_spec/ccv_2022/models.py
@@ -237,11 +237,14 @@ class VariantOncogenicityEvidenceLine(EvidenceLine, MethodTypeCriterionValidatio
         self._validate_evidence_outcome(SYSTEM, CCV_CODE_PATTERN, is_required=False)
         self._validate_criterion_specified_by()
 
-        if self.evidenceOutcome:
-            self._validate_method_type_evidence_outcome(
-                self.specifiedBy.methodType,
-                self.evidenceOutcome.primaryCoding.code.root,
-            )
+        evidence_outcome = (
+            self.evidenceOutcome.primaryCoding.code.root
+            if self.evidenceOutcome
+            else None
+        )
+        self._validate_method_type_evidence_outcome(
+            self.specifiedBy.methodType, evidence_outcome
+        )
         return self
 
 

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -616,7 +616,7 @@ def test_variant_onco_el_no_evidence_outcome():
     """Test that VariantOncogenicityEvidenceLine validates without evidence
     outcome
     """
-    assert VariantOncogenicityEvidenceLine(
+    valid = VariantOncogenicityEvidenceLine(
         type="EvidenceLine",
         specifiedBy={
             "type": "Method",
@@ -631,6 +631,17 @@ def test_variant_onco_el_no_evidence_outcome():
         scoreOfEvidenceProvided=0,
         evidenceOutcome=None,
     )
+
+    assert valid
+
+    invalid = valid.model_dump()
+    invalid["specifiedBy"]["methodType"] = "dummy"
+
+    with pytest.raises(
+        ValueError,
+        match="'dummy' is not a valid VariantOncogenicityEvidenceLine.MethodType",
+    ):
+        VariantOncogenicityEvidenceLine.model_validate(invalid)
 
 
 def test_aac_statement():

--- a/tests/validation/test_va_spec_models.py
+++ b/tests/validation/test_va_spec_models.py
@@ -21,6 +21,7 @@ from ga4gh.va_spec.base import (
     ExperimentalVariantFunctionalImpactStudyResult,
 )
 from ga4gh.va_spec.base.core import (
+    Direction,
     EvidenceLine,
     Method,
     Statement,
@@ -609,6 +610,27 @@ def test_variant_onco_el():
         match="`strengthOfEvidenceProvided` is not allowed when `directionOfEvidenceProvided` is 'neutral'.",
     ):
         VariantOncogenicityEvidenceLine(**invalid_params)
+
+
+def test_variant_onco_el_no_evidence_outcome():
+    """Test that VariantOncogenicityEvidenceLine validates without evidence
+    outcome
+    """
+    assert VariantOncogenicityEvidenceLine(
+        type="EvidenceLine",
+        specifiedBy={
+            "type": "Method",
+            "reportedIn": {
+                "type": "Document",
+                "pmid": "35101336",
+                "name": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022",
+            },
+            "methodType": "functional_assay",
+        },
+        directionOfEvidenceProvided=Direction.NEUTRAL,
+        scoreOfEvidenceProvided=0,
+        evidenceOutcome=None,
+    )
 
 
 def test_aac_statement():


### PR DESCRIPTION
close #70

Only directionOfEvidenceProvided and specifiedBy are 
https://github.com/ga4gh/va-spec/blob/56ada2eee167abc8b03ad28fc3f7d94ecb6578cd/schema/va-spec/ccv-2022/json/VariantOncogenicityEvidenceLine#L401-L403